### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mf-connect-lab/18638956-7d83-4566-a363-0b091a0ff71e/05750e08-644e-4183-b654-08db8f7afaf1/_apis/work/boardbadge/de9ccb03-a6a7-40f8-8d89-aba6a3fc149f)](https://dev.azure.com/mf-connect-lab/18638956-7d83-4566-a363-0b091a0ff71e/_boards/board/t/05750e08-644e-4183-b654-08db8f7afaf1/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#29](https://dev.azure.com/mf-connect-lab/18638956-7d83-4566-a363-0b091a0ff71e/_workitems/edit/29). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.